### PR TITLE
Update Readme.md to install jspm 0.17.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,7 @@ Installation:
 ```
 git clone https://github.com/born2net/studioDashboard.git
 cd studioDashboard
-npm install jspm -g
+npm install jspm@beta -g
 npm install
 ```
 


### PR DESCRIPTION
At the time of writing, the installed version of jspm will resolve to 0.16.x, which looks for config.js and tries to create it. 0.17.x works properly with jspm.config.js